### PR TITLE
Fix pv icons and linebreaks in labels

### DIFF
--- a/digiplan/static/config/energy_settings_panel.json
+++ b/digiplan/static/config/energy_settings_panel.json
@@ -113,7 +113,7 @@
   },
   "s_pv_ff_4": {
     "class": "js-slider js-slider-detail-panel",
-    "label": "{% trans 'Agri-PV (vertikal) auf Agrarflächen mittlerer Bodengüte\nGemeinsame Nutzung mit Landwirtschaft (%)' %} ",
+    "label": "{% trans 'Agri-PV (vertikal) auf Agrarflächen mittlerer Bodengüte<br>Gemeinsame Nutzung mit Landwirtschaft (%)' %} ",
     "max": 100,
     "min": 0,
     "start": 0,
@@ -123,7 +123,7 @@
   },
   "s_pv_ff_5": {
     "class": "js-slider js-slider-detail-panel",
-    "label": "{% trans 'Agri-PV (hoch aufgeständert) über Dauerkulturen\nGemeinsame Nutzung mit Landwirtschaft (%)' %} ",
+    "label": "{% trans 'Agri-PV (hoch aufgeständert) über Dauerkulturen<br>Gemeinsame Nutzung mit Landwirtschaft (%)' %} ",
     "max": 100,
     "min": 0,
     "start": 0,

--- a/digiplan/static/scss/layouts/_panel.scss
+++ b/digiplan/static/scss/layouts/_panel.scss
@@ -475,7 +475,7 @@
 
   .sidepanel__tabs .sidepanel-tabs {
     @include custom-tabs {
-      
+
       .sidepanel-tabs__nav-item .sidepanel-tabs__nav-link {
         padding-top: 0.25rem !important;
         padding-bottom: 0.25rem !important;
@@ -606,7 +606,7 @@
       @include settings-details-slider($epp-color-pv-low);
 
       &__label:before {
-        background-image: url('../../images/icons/pv_low_outlined.svg');
+        background-image: url('/static/images/icons/pv_low_outlined.svg');
       }
     }
 
@@ -614,7 +614,7 @@
       @include settings-details-slider($epp-color-pv-medium);
 
       &__label:before {
-        background-image: url('../../images/icons/pv_medium_outlined.svg');
+        background-image: url('/static/images/icons/pv_medium_outlined.svg');
       }
     }
 
@@ -622,7 +622,7 @@
       @include settings-details-slider($epp-color-pv-high);
 
       &__label:before {
-        background-image: url('../../images/icons/pv_high_outlined.svg');
+        background-image: url('/static/images/icons/pv_high_outlined.svg');
       }
     }
   }

--- a/digiplan/templates/widgets/slider.html
+++ b/digiplan/templates/widgets/slider.html
@@ -10,7 +10,7 @@
 <div class="c-slider {{ field.name }}">
   {% if field.label %}
     <div class="c-slider__label">
-    <span>{{ field.label }}{% if field.help_text %}
+    <span>{{ field.label | safe }}{% if field.help_text %}
       {% include 'widgets/info_button.html' with description=field.help_text %}{% endif %}</span>
       {% if field.field.widget.attrs|dict_lookup_filter:"data-has-sidepanel" == "true" %}
         <span class="c-slider__label--more">


### PR DESCRIPTION
I fixed PV icon image path and added line breaks to labels (by using `<br>` and marking label as safe).
Could you check if everything is working and looking nice, @bmlancien ? thx