### PR TITLE
PV map controls get focus and highlighted when selecting PV details

### DIFF
--- a/digiplan/map/views.py
+++ b/digiplan/map/views.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.http import HttpRequest, response
 from django.views.generic import TemplateView
 from django_mapengine import views
+from django.utils.translation import gettext_lazy as _
 
 from digiplan import __version__
 from digiplan.map import config
@@ -27,7 +28,7 @@ class MapGLView(TemplateView, views.MapEngineMixin):
             category: [forms.StaticLayerForm(layer) for layer in layers]
             for category, layers in map_config.LEGEND.items()
         },
-        "pv_map_control": "Settlements Infrastructure",
+        "pv_map_control": _("Settlements Infrastructure"),
         "store_hot_init": config.STORE_HOT_INIT,
         "oemof_scenario": settings.OEMOF_SCENARIO,
     }

--- a/digiplan/map/views.py
+++ b/digiplan/map/views.py
@@ -27,6 +27,7 @@ class MapGLView(TemplateView, views.MapEngineMixin):
             category: [forms.StaticLayerForm(layer) for layer in layers]
             for category, layers in map_config.LEGEND.items()
         },
+        "pv_map_control": "Settlements Infrastructure",
         "store_hot_init": config.STORE_HOT_INIT,
         "oemof_scenario": settings.OEMOF_SCENARIO,
     }

--- a/digiplan/static/js/sliders.js
+++ b/digiplan/static/js/sliders.js
@@ -34,6 +34,8 @@ const potentialWindLayers = [
   "potentialarea_wind_stp_2027",
 ];
 
+const pvMapControl = document.getElementsByClassName("map__layers-pv")[0];
+
 // Setup
 
 $(".js-slider.js-slider-panel.js-power-mix").ionRangeSlider({
@@ -99,6 +101,7 @@ PubSub.subscribe(
   showOrHidePotentialLayersOnMoreLabelClick,
 );
 PubSub.subscribe(eventTopics.PV_CONTROL_ACTIVATED, showPVLayers);
+PubSub.subscribe(eventTopics.PV_CONTROL_ACTIVATED, highlightPVMapControls);
 PubSub.subscribe(eventTopics.PV_ROOF_CONTROL_ACTIVATED, showPVRoofLayers);
 PubSub.subscribe(eventTopics.WIND_CONTROL_ACTIVATED, showWindLayers);
 
@@ -408,6 +411,15 @@ function hidePotentialLayers(msg) {
     .concat(potentialWindLayers)) {
     map.setLayoutProperty(layer, "visibility", "none");
   }
+  return logMessage(msg);
+}
+
+function highlightPVMapControls(msg) {
+  pvMapControl.scrollIntoView();
+  pvMapControl.classList.add("blinking");
+  setTimeout(function () {
+    pvMapControl.classList.remove("blinking");
+  }, 2000);
   return logMessage(msg);
 }
 

--- a/digiplan/static/scss/app.scss
+++ b/digiplan/static/scss/app.scss
@@ -30,3 +30,4 @@
 @import 'layouts/main';
 @import 'layouts/panel';
 @import 'layouts/results';
+@import 'layouts/blinking';

--- a/digiplan/static/scss/layouts/_blinking.scss
+++ b/digiplan/static/scss/layouts/_blinking.scss
@@ -1,0 +1,9 @@
+@keyframes blink {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.blinking {
+  animation: blink 1s infinite;
+}

--- a/digiplan/templates/components/layer_box.html
+++ b/digiplan/templates/components/layer_box.html
@@ -10,7 +10,7 @@
   </div>
 
   {% for category, layers in area_switches.items %}
-    <p class="map__layers-heading">{{ category }}</p>
+    <p class="map__layers-heading {% if category == pv_map_control %}map__layers-pv{% endif %}">{{ category }}</p>
 
     {% for layer in layers %}
       {{ layer }}


### PR DESCRIPTION
PV map controls (for now I choose Settlement Infrastructure - can be changed later) get highlighted and scrolled to when activating PV details.
@bmlancien I added a new `_blinking.scss` to app.scss as idid not know where to put it - could you move this were it belongs?