### PR TITLE
Adapt municipality label font size according to zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - coupling of duplicated map panel controls
 - dependabot
 
+### Changed
+- Adapt municipality label font size according to zoom level
+
 ### Fixed
 - duplicate loading of JS modules due to missing module support in django staticfile storage
 - settlement 200m layer is coupled to settlement layer (de)-activation

--- a/digiplan/static/config/layer_styles.json
+++ b/digiplan/static/config/layer_styles.json
@@ -21,6 +21,15 @@
   "region-label": {
     "type": "symbol",
     "layout": {
+      "text-size": [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        8,
+        10,
+        14,
+        30
+      ],
       "text-field": "{name}",
       "text-letter-spacing": 0.04,
       "text-radial-offset": 2,


### PR DESCRIPTION
Closes #49 

I connected font size to zoom level - thus in lower zoom levels, font size is decreased in order to tidy up map view.
Maybe this helps?
