### PR TITLE
Improve/add third slider mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - dependabot
 - key results for wind, pv ground and pv roof settings panels
 - scenario settings
+- additional slider marker
 
 ### Changed
 - Adapt municipality label font size according to zoom level

--- a/digiplan/map/config.py
+++ b/digiplan/map/config.py
@@ -81,11 +81,16 @@ def get_slider_marks() -> dict:
                 slider_marks[param_name].append(("Heute", param_data["status_quo"]))
             else:
                 slider_marks[param_name] = [("Heute", param_data["status_quo"])]
-        if "future_scenario" in param_data:
+        if "future_scenario_2030" in param_data:
             if param_name in slider_marks:
-                slider_marks[param_name].append(("BB2040", param_data["future_scenario"]))
+                slider_marks[param_name].append(("BB2030", param_data["future_scenario_2030"]))
             else:
-                slider_marks[param_name] = [("BB2040", param_data["future_scenario"])]
+                slider_marks[param_name] = [("BB2030", param_data["future_scenario_2030"])]
+        if "future_scenario_2040" in param_data:
+            if param_name in slider_marks:
+                slider_marks[param_name].append(("BB2040", param_data["future_scenario_2040"]))
+            else:
+                slider_marks[param_name] = [("BB2040", param_data["future_scenario_2040"])]
     return slider_marks
 
 

--- a/digiplan/map/config.py
+++ b/digiplan/map/config.py
@@ -83,14 +83,14 @@ def get_slider_marks() -> dict:
                 slider_marks[param_name] = [("Heute", param_data["status_quo"])]
         if "future_scenario_2030" in param_data:
             if param_name in slider_marks:
-                slider_marks[param_name].append(("BB2030", param_data["future_scenario_2030"]))
+                slider_marks[param_name].append(("BB30", param_data["future_scenario_2030"]))
             else:
-                slider_marks[param_name] = [("BB2030", param_data["future_scenario_2030"])]
+                slider_marks[param_name] = [("BB30", param_data["future_scenario_2030"])]
         if "future_scenario_2040" in param_data:
             if param_name in slider_marks:
-                slider_marks[param_name].append(("BB2040", param_data["future_scenario_2040"]))
+                slider_marks[param_name].append(("BB40", param_data["future_scenario_2040"]))
             else:
-                slider_marks[param_name] = [("BB2040", param_data["future_scenario_2040"])]
+                slider_marks[param_name] = [("BB40", param_data["future_scenario_2040"])]
     return slider_marks
 
 

--- a/digiplan/map/datapackage.py
+++ b/digiplan/map/datapackage.py
@@ -272,7 +272,7 @@ def get_capacities_from_sliders(year: int) -> pd.Series:
         lookup = "status_quo"
         bioenergy_power = 55.7  # Workaround for bioenergy as there's no slider
     elif year == 2045:  # noqa: PLR2004
-        lookup = "future_scenario"
+        lookup = "future_scenario_2040"
         bioenergy_power = 0
     else:
         msg = "Unknown year"

--- a/digiplan/static/js/scenarios.js
+++ b/digiplan/static/js/scenarios.js
@@ -1,5 +1,5 @@
 import { getCurrentMenuTab } from "./menu.js";
-import { detailSliders, panelSliders } from "./sliders.js";
+import { detailSliders, panelSliders, updateSliderMarks } from "./sliders.js";
 
 const scenarioSettings = JSON.parse(
   document.getElementById("scenario_settings").textContent,
@@ -148,6 +148,7 @@ function adaptSlidersScenario(msg, scenario) {
     const sliderValue = scenarioSettings[scenario][slider.id];
     $(`#${slider.id}`).data("ionRangeSlider").update({ from: sliderValue });
   }
+  updateSliderMarks();
   PubSub.publish(eventTopics.POWER_PANEL_SLIDER_CHANGE);
   return logMessage(msg);
 }

--- a/digiplan/static/js/sliders.js
+++ b/digiplan/static/js/sliders.js
@@ -306,7 +306,7 @@ function createPercentagesOfPowerSources(msg) {
 }
 
 /* when the other forms get Status Quo marks, there needs to be an iteration over the forms! (line 117)*/
-function updateSliderMarks(msg) {
+export function updateSliderMarks(msg) {
   for (let [slider_name, slider_marks] of Object.entries(
     store.cold.slider_marks,
   )) {

--- a/digiplan/templates/components/panel_3_scenarios.html
+++ b/digiplan/templates/components/panel_3_scenarios.html
@@ -10,7 +10,7 @@
         <div class="panel-card__content">
           <div class="panel-card__name">
             <div>
-              Energiestrategie Brandenburg 2030<br>(BB2030)
+              Energiestrategie Brandenburg 2030<br>(BB30)
             </div>
             <div class="scenario-star">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#2348C3" class="bi bi-star-fill" viewBox="0 0 16 16">
@@ -53,7 +53,7 @@
         <div class="panel-card__content">
           <div class="panel-card__name">
             <div>
-              Energiestrategie Brandenburg 2040<br>(BB2040)
+              Energiestrategie Brandenburg 2040<br>(BB40)
             </div>
             <div class="scenario-star">
             </div>


### PR DESCRIPTION
third slider marks can be added in the energy_panel and heat_panel jsons in data/digipipe/settings

names for sliders are atm: 
status_quo -> Heute
future_scenario_2030 -> BB2030
future_scenario_2040 -> BB2040